### PR TITLE
fixes blog-map post's tag capitalization

### DIFF
--- a/content/post/blog-map.md
+++ b/content/post/blog-map.md
@@ -3,7 +3,7 @@ title: "Navigating This Blog"
 date: '2100-01-01T15:00:00+0000'
 description: Here's a map to help you quickly find what you're looking for on the NI4AI blog.
 featuredImage: '/assets/images/post/blog-map/blog_diagram.svg'
-tags: ["Conversations", "NI4AI-Platform"]
+tags: ["conversations", "ni4ai-platform"]
 author: laurel
 ---
 
@@ -18,7 +18,7 @@ Don’t see what you’re looking for? Have a topic you've been curious about? S
 
 ## Conversations
 
-These posts cover what's happening in the industry or on the grid. They're geared at putting the data in context, and at giving you ideas for moving the industry forwards. 
+These posts cover what's happening in the industry or on the grid. They're geared at putting the data in context, and at giving you ideas for moving the industry forwards.
 - [Wildfire mitigation](https://blog.ni4ai.org/post/2020-07-29-fire-season/)
 - [Data sharing](https://blog.ni4ai.org/post/2020-07-29-whos-in/)
 - [On building expertise](https://blog.ni4ai.org/post/2020-07-31-expertise-for-expert/)
@@ -27,7 +27,7 @@ These posts cover what's happening in the industry or on the grid. They're geare
 
 ## Data Descriptions
 
-These posts offer documentation of the datasets hosted in the platform. 
+These posts offer documentation of the datasets hosted in the platform.
 - [Sunshine](https://blog.ni4ai.org/tags/sunshine-data)
 - [EKG data](https://blog.ni4ai.org/tags/ekg-data)
 - [Find more](https://blog.ni4ai.org/tags/ni4ai-data/)
@@ -44,7 +44,7 @@ This posts will help you get set up using the platform.
 
 ## Tutorials & Analytics
 
-These posts describe analytical methods for interpreting the data. They provide sample code and jupyter notebooks that will help you get started. 
+These posts describe analytical methods for interpreting the data. They provide sample code and jupyter notebooks that will help you get started.
 - [Voltage sag detection](https://blog.ni4ai.org/post/2020-04-15-voltage-sags/)
 - [Phase angle analysis](https://blog.ni4ai.org/post/2020-07-29-what-is-the-angle-part-2/)
 - [Phasor visualization](https://blog.ni4ai.org/post/2020-04-25-visualizing-phasor-timeseries/)


### PR DESCRIPTION
- @lndunn and I found a small issue on PR #43 after we'd already merged it. That was: https://github.com/PingThingsIO/blog/pull/43/files/3fbfc482f33118382a94b7af9a9901d95501e21c#diff-8ab134720789c7b6882617218c5a6211
- This PR corrects the capitalization of those tags.