### PR TITLE
Quick clean up from QA on the build output

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -69,7 +69,6 @@ module.exports = {
             resolve: `gatsby-remark-images`,
             options: {
               maxWidth: 590,
-              wrapperStyle: fluidResult => `height:${Math.round(fluidResult.aspectRatio)}vw;`
             }
           },
           {

--- a/src/templates/Article.js
+++ b/src/templates/Article.js
@@ -33,8 +33,6 @@ const Caption = styled(BaseCaption)`
     background-size: contain;
     background-position: center;
     background-repeat: no-repeat;
-    ${props =>
-      `filter: drop-shadow(0 0 0.75rem ${props.theme.colors.foreground3});`}
   }
   p {
     &:empty {


### PR DESCRIPTION
I ran a yarn build to QA the output from my recent changes, and I noticed the drop shadow I added didn't look good on wider screens so I removed it. I also removed the wrapperStyle callback, since it wasn't being used.